### PR TITLE
Reset to Ready when No Note Detect

### DIFF
--- a/src/main/cpp/mechanisms/noteManager/decoratormods/ReadyState.cpp
+++ b/src/main/cpp/mechanisms/noteManager/decoratormods/ReadyState.cpp
@@ -155,6 +155,11 @@ bool ReadyState::IsTransitionCondition(bool considerGamepadTransitions)
 		transition = true;
 		reason = 7;
 	}
+	else if (currentState == static_cast<int>(m_mechanism->STATE_HOLD_FEEDER) && (m_mechanism->GetTransitionFromHoldFeedToReady()))
+	{
+		transition = true;
+		reason = 8;
+	}
 
 	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("Ready"), string("Transition Reason"), reason); // Remove logging after Note management is all verifed
 	return (transition);

--- a/src/main/cpp/mechanisms/noteManager/decoratormods/holdFeederState.cpp
+++ b/src/main/cpp/mechanisms/noteManager/decoratormods/holdFeederState.cpp
@@ -46,12 +46,28 @@ void holdFeederState::Init()
 
 	m_genState->Init();
 	m_mechanism->UpdateTarget(RobotElementNames::MOTOR_CONTROLLER_USAGE::NOTE_MANAGER_LAUNCHER_ANGLE, m_mechanism->getlauncherAngle()->GetCounts());
+
+	m_NoteMisdetectionCounter = 0;
 }
 
 void holdFeederState::Run()
 {
 	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, string("ArrivedAt"), string("holdFeederState"), string("run"));
 	m_genState->Run();
+
+	bool launcherSensor = m_mechanism->getlauncherSensor()->Get();
+	bool feederSensor = m_mechanism->getfeederSensor()->Get();
+	if ((launcherSensor == false) && (feederSensor == false))
+	{
+		if (m_NoteMisdetectionCounter < m_NoteMisdetectionThreshhold)
+			m_NoteMisdetectionCounter++;
+	}
+	else
+	{
+		if (m_NoteMisdetectionCounter > 0)
+			m_NoteMisdetectionCounter--;
+	}
+	m_mechanism->SetTransitionFromHoldFeedToReady(m_NoteMisdetectionCounter == m_NoteMisdetectionThreshhold);
 }
 
 void holdFeederState::Exit()

--- a/src/main/cpp/mechanisms/noteManager/decoratormods/holdFeederState.h
+++ b/src/main/cpp/mechanisms/noteManager/decoratormods/holdFeederState.h
@@ -44,5 +44,8 @@ namespace noteManagerStates
 	private:
 		noteManagerAllStatesStateGen *m_genState;
 		noteManager *m_mechanism;
+
+		int m_NoteMisdetectionCounter;
+		const int m_NoteMisdetectionThreshhold = 500 / 20; // Half a second
 	};
 }

--- a/src/main/cpp/mechanisms/noteManager/decoratormods/noteManager.h
+++ b/src/main/cpp/mechanisms/noteManager/decoratormods/noteManager.h
@@ -66,6 +66,9 @@ public:
 	bool autoLaunchReady();
 	bool HasNote() const;
 
+	bool GetTransitionFromHoldFeedToReady() { return m_TransitionFromHoldFeedToReady; }
+	void SetTransitionFromHoldFeedToReady(bool state) { m_TransitionFromHoldFeedToReady = state; }
+
 private:
 	double GetFilteredValue(double latestValue, std::deque<double> &previousValues, double previousAverage);
 
@@ -86,4 +89,6 @@ private:
 	double MonitorForNoteInIntakes();
 	bool m_noteInIntake = false;
 	bool m_noteInFeeder = false;
+
+	bool m_TransitionFromHoldFeedToReady = false;
 };


### PR DESCRIPTION
noteManager Goes back To Ready from holdFeeder if both hold and launch sensor do not detect a note