### PR TITLE
Added optional LaserCAN properties to SwerveModule and SwerveChassis

### DIFF
--- a/src/main/cpp/chassis/SwerveChassis.cpp
+++ b/src/main/cpp/chassis/SwerveChassis.cpp
@@ -565,3 +565,20 @@ void SwerveChassis::ReadConstants(string configfilename)
         Logger::GetLogger()->LogData(LOGGER_LEVEL::ERROR, m_networkTableName, string("Config File not found"), configfilename);
     }
 }
+
+void SwerveChassis::DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::LaserCanROI roi, grpl::LaserCanTimingBudget timingBudget)
+{
+    m_laserCan = new grpl::LaserCan(m_pigeon->GetDeviceID());
+    m_laserCan->set_ranging_mode(rangingMode);
+    m_laserCan->set_roi(roi);
+    m_laserCan->set_timing_budget(timingBudget);
+}
+
+std::optional<uint16_t> SwerveChassis::GetLaserValue()
+{
+    std::optional<grpl::LaserCanMeasurement> distance = m_laserCan->get_measurement();
+    if (distance.has_value() && distance.value().status == grpl::LASERCAN_STATUS_VALID_MEASUREMENT)
+    {
+        return distance.value().distance_mm;
+    }
+}

--- a/src/main/cpp/chassis/SwerveChassis.cpp
+++ b/src/main/cpp/chassis/SwerveChassis.cpp
@@ -576,6 +576,10 @@ void SwerveChassis::DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::
 
 std::optional<uint16_t> SwerveChassis::GetLaserValue()
 {
+    if (m_laserCan == nullptr)
+    {
+        return std::nullopt;
+    }
     std::optional<grpl::LaserCanMeasurement> distance = m_laserCan->get_measurement();
     if (distance.has_value() && distance.value().status == grpl::LASERCAN_STATUS_VALID_MEASUREMENT)
     {

--- a/src/main/cpp/chassis/SwerveChassis.h
+++ b/src/main/cpp/chassis/SwerveChassis.h
@@ -29,6 +29,7 @@
 #include "units/length.h"
 #include "units/velocity.h"
 #include "wpi/DataLog.h"
+#include "grpl/LaserCan.h"
 
 #include "chassis/ChassisOptionEnums.h"
 #include "chassis/driveStates/ISwerveDriveState.h"
@@ -128,6 +129,8 @@ public:
     void LogInformation() override;
     void DataLog() override;
 
+    std::optional<uint16_t> GetLaserValue();
+
 private:
     ISwerveDriveOrientation *GetHeadingState(const ChassisMovement &moveInfo);
     ISwerveDriveState *GetDriveState(ChassisMovement &moveInfo);
@@ -181,4 +184,7 @@ private:
     std::array<frc::SwerveModuleState, 4U> m_targetStates;
 
     frc::Timer m_velocityTimer;
+
+    grpl::LaserCan *m_laserCan = nullptr;
+    void DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::LaserCanROI roi, grpl::LaserCanTimingBudget timingBudget);
 };

--- a/src/main/cpp/chassis/SwerveModule.cpp
+++ b/src/main/cpp/chassis/SwerveModule.cpp
@@ -514,6 +514,10 @@ void SwerveModule::DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::L
 
 std::optional<uint16_t> SwerveModule::GetLaserValue()
 {
+    if (m_laserCan == nullptr)
+    {
+        return std::nullopt;
+    }
     std::optional<grpl::LaserCanMeasurement> distance = m_laserCan->get_measurement();
     if (distance.has_value() && distance.value().status == grpl::LASERCAN_STATUS_VALID_MEASUREMENT)
     {

--- a/src/main/cpp/chassis/SwerveModule.cpp
+++ b/src/main/cpp/chassis/SwerveModule.cpp
@@ -503,3 +503,20 @@ void SwerveModule::ReadConstants(string configfilename) /// TO DO need to update
         Logger::GetLogger()->LogData(LOGGER_LEVEL::ERROR_ONCE, m_networkTableName, string("Config File not found"), configfilename);
     }
 }
+
+void SwerveModule::DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::LaserCanROI roi, grpl::LaserCanTimingBudget timingBudget)
+{
+    m_laserCan = new grpl::LaserCan(m_driveTalon->GetDeviceID());
+    m_laserCan->set_ranging_mode(rangingMode);
+    m_laserCan->set_roi(roi);
+    m_laserCan->set_timing_budget(timingBudget);
+}
+
+std::optional<uint16_t> SwerveModule::GetLaserValue()
+{
+    std::optional<grpl::LaserCanMeasurement> distance = m_laserCan->get_measurement();
+    if (distance.has_value() && distance.value().status == grpl::LASERCAN_STATUS_VALID_MEASUREMENT)
+    {
+        return distance.value().distance_mm;
+    }
+}

--- a/src/main/cpp/chassis/SwerveModule.h
+++ b/src/main/cpp/chassis/SwerveModule.h
@@ -39,6 +39,7 @@
 // Third Party
 #include "ctre/phoenix6/TalonFX.hpp"
 #include "ctre/phoenix6/CANcoder.hpp"
+#include "grpl/LaserCan.h"
 
 class SwerveModule : public LoggableItem
 {
@@ -99,6 +100,8 @@ public:
     void StopMotors();
     void LogInformation() override;
 
+    std::optional<uint16_t> GetLaserValue();
+
 private:
     void InitDriveMotor(bool inverted);
     void InitTurnMotorEncoder(
@@ -147,4 +150,7 @@ private:
     bool m_velocityControlled = false;
     bool m_useFOC = false;
     std::string m_networkTableName;
+
+    void DefineLaserCan(grpl::LaserCanRangingMode rangingMode, grpl::LaserCanROI roi, grpl::LaserCanTimingBudget timingBudget);
+    grpl::LaserCan *m_laserCan;
 };


### PR DESCRIPTION
Added all the config options according to the header file and a method to get a valid measurement in millimeters from the sensor. 

I pretty much copied the same code to both classes, but we could consolidate it in some LaserCAN wrapper class instead. I just didn't know where to put that in the codebase